### PR TITLE
helm3 needs --create-namespace option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ deploy: make-manifest
 
 .PHONY: helm-deploy
 helm-deploy: install-crd
-	helm upgrade --install $(RELEASE_NAME) --namespace $(NAMESPACE) --set "image.tag=$(VERSION)" -f chart/rate-limit-operator/values.yaml  chart/rate-limit-operator
+	helm upgrade --install $(RELEASE_NAME) --namespace $(NAMESPACE) --create-namespace --set "image.tag=$(VERSION)" -f chart/rate-limit-operator/values.yaml  chart/rate-limit-operator
 
 .PHONY: install-crd
 install-crd:


### PR DESCRIPTION
Hi, I was following the install readme based on the helm option, but originally the makefile fails with `helm-deploy` target:

```
Makefile:91: warning: overriding commands for target `deploy'
Makefile:53: warning: ignoring old commands for target `deploy'
cp config/crd/bases/networking.softonic.io_ratelimits.yaml chart/rate-limit-operator/crds/networking.softonic.io_ratelimits.yaml
helm upgrade --install rate-limit-operator --namespace rate-limit-operator-system --set "image.tag=1.0.18-dev" -f chart/rate-limit-operator/values.yaml  chart/rate-limit-operator
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/andre.ferraz/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/andre.ferraz/.kube/config
Release "rate-limit-operator" does not exist. Installing it now.
Error: create: failed to create: namespaces "rate-limit-operator-system" not found
make: *** [helm-deploy] Error 1
```

Debugging the problem, looks like Helm3 needs to use the option --create-namespace to be able to create the namespace before applying the manifests of the chart, so this PR includes this option for the Makefile `helm-deploy` target

After the fix:
```
❯ make helm-deploy                                                                                                                                                                                                                                                                                                         ─╯
Makefile:91: warning: overriding commands for target `deploy'
Makefile:53: warning: ignoring old commands for target `deploy'
cp config/crd/bases/networking.softonic.io_ratelimits.yaml chart/rate-limit-operator/crds/networking.softonic.io_ratelimits.yaml
helm upgrade --install rate-limit-operator --namespace rate-limit-operator-system --create-namespace --set "image.tag=1.0.18-dev" -f chart/rate-limit-operator/values.yaml  chart/rate-limit-operator
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/andre.ferraz/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/andre.ferraz/.kube/config
Release "rate-limit-operator" does not exist. Installing it now.
NAME: rate-limit-operator
LAST DEPLOYED: Wed Aug 17 13:57:22 2022
NAMESPACE: rate-limit-operator-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
